### PR TITLE
Icon 생성 버그 수정 (아이콘 생성 불가 버그, 투명 아이콘 생성 버그)

### DIFF
--- a/Editor/Util/IconUtil.cs
+++ b/Editor/Util/IconUtil.cs
@@ -98,18 +98,19 @@ namespace dog.miruku.inventory
                     }
                 }
             }
-
-            int centerX = (minX + maxX) / 2, centerY = (minY + maxY) / 2;
+            
             var size = Mathf.Max(maxX - minX, maxY - minY);
             if (size < 0)
             {
                 size = 1;
             }
-            var pixels = image.GetPixels(centerX - size / 2, centerY - size / 2, size, size);
-            var clippedIcon = new Texture2D(size, size, TextureFormat.ARGB32, false);
-            clippedIcon.SetPixels(pixels);
-            clippedIcon.Apply();
 
+            int croppedSizeX = maxX - minX, croppedSizeY = maxY - minY;
+            var croppedPixels = image.GetPixels(minX, minY, croppedSizeX, croppedSizeY);
+            var clippedIcon = new Texture2D(size, size, TextureFormat.ARGB32, false);
+            MakeTexture2DClear(clippedIcon, size, size);
+            clippedIcon.SetPixels(size / 2 - croppedSizeX / 2, size / 2 - croppedSizeY / 2, croppedSizeX, croppedSizeY, croppedPixels);
+            clippedIcon.Apply();
 
             // Resize and save
             var resizedIcon = ResizeTexture(clippedIcon, 256, 256);
@@ -124,5 +125,28 @@ namespace dog.miruku.inventory
             return AssetDatabase.LoadAssetAtPath<Texture2D>(path);
         }
 
+        private static void MakeTexture2DClear(Texture2D tex2D, int width, int height)
+        {
+            var clearColors = new Color[width * height];
+            
+            int blockSize = width; 
+            Color[] initialBlock = new Color[blockSize];
+            for (int i = 0; i < blockSize; i++)
+            {
+                initialBlock[i] = Color.clear;
+            }
+
+            int remaining = clearColors.Length;
+            int copyPos = 0;
+            while (remaining > 0)
+            {
+                int copyLength = Mathf.Min(blockSize, remaining);
+                System.Array.Copy(initialBlock, 0, clearColors, copyPos, copyLength);
+                remaining -= copyLength;
+                copyPos += copyLength;
+            }
+
+            tex2D.SetPixels(clearColors);
+        }
     }
 }

--- a/Editor/Util/IconUtil.cs
+++ b/Editor/Util/IconUtil.cs
@@ -30,6 +30,10 @@ namespace dog.miruku.inventory
                 clone.transform.SetParent(cloned.transform);
                 clone.SetActive(true);
             }
+            
+            // Set the layers to the hip layers
+            const int targetLayer = 21; // layer: reserved4
+            ChangeLayerRecursively(cloned, targetLayer);
 
             // Setup camera
             cloned.transform.position = Vector3.zero;
@@ -37,6 +41,7 @@ namespace dog.miruku.inventory
             var camera = cameraObject.AddComponent<Camera>();
             camera.clearFlags = CameraClearFlags.Nothing;
             camera.nearClipPlane = 0.00001f;
+            camera.cullingMask = 2 << (targetLayer - 1);
 
             // Calculate bound
             var boundList = cloned.GetComponentsInChildren<Renderer>().Select<Renderer, Bounds?>(e =>
@@ -61,8 +66,7 @@ namespace dog.miruku.inventory
             var minDistance = (maxExtent) / Mathf.Sin(Mathf.Deg2Rad * camera.fieldOfView / 2.0f);
             var center = bounds.center;
 
-            cloned.transform.position = new Vector3(5000, 5000, 5000);
-            camera.transform.position = center + new Vector3(5000, 5000, 5000) + Vector3.forward * minDistance;
+            camera.transform.position = center + cloned.transform.position + Vector3.forward * minDistance;
 
             var captureWidth = 2048;
             var captureHeight = 2048;
@@ -123,6 +127,15 @@ namespace dog.miruku.inventory
             importer.alphaIsTransparency = true;
             importer.SaveAndReimport();
             return AssetDatabase.LoadAssetAtPath<Texture2D>(path);
+        }
+        
+        private static void ChangeLayerRecursively(GameObject gameObject, int layer)
+        {
+            gameObject.layer = layer;
+            foreach (Transform child in gameObject.transform)
+            {
+                ChangeLayerRecursively(child.gameObject, layer);
+            }
         }
 
         private static void MakeTexture2DClear(Texture2D tex2D, int width, int height)


### PR DESCRIPTION
# 아이콘 생성 불가 버그
가로와 세로 중 더 큰 길이를 선택하여 정사각형 사이즈로 추출할 때, Texture2D 사이즈의 범위를 초과하는 곳을 참조하는 문제 발생
Target Texture2D를 투명하게 만든 뒤, 중앙에 렌더링하여 투명 Padding 만들 수 있도록 수정

# 사진이 찍히지 않는 버그
Skinned Mesh Renderer가 아바타 Bone에 묶여있어 5000, 5000으로 포지션으로 이동되지 않아서 문제 발생
기존 포지션을 유지하며 Layer만 변경하여 촬영하도록 수정