### PR TITLE
SkinnedMeshRenderer의 업데이트가 이루어지기 전의 bound를 참조하여 카메라의 위치가 결정되던 문제 수정

### DIFF
--- a/Editor/Util/IconUtil.cs
+++ b/Editor/Util/IconUtil.cs
@@ -44,6 +44,11 @@ namespace dog.miruku.inventory
             camera.cullingMask = 2 << (targetLayer - 1);
 
             // Calculate bound
+            foreach (var renderer in cloned.GetComponentsInChildren<SkinnedMeshRenderer>())
+            {
+                renderer.updateWhenOffscreen = true; // Force update for SkinnedMeshRenderer
+            }
+            
             var boundList = cloned.GetComponentsInChildren<Renderer>().Select<Renderer, Bounds?>(e =>
             {
                 if (e.TryGetComponent(out SkinnedMeshRenderer renderer))


### PR DESCRIPTION
# 현상
SkinnedMeshRenderer의 위치가 업데이트 되기 이전의 좌표를 참고하여 카메라의 위치가 결정됨
따라서 제대로 대상을 비추지 못한다.

# 해결
SkinnedMeshRenderer의 updateWhenOffscreen 플래그를 true로 두어 강제 Update를 유도하여 해결함