### PR TITLE
Menu Installer 통합 버그 수정

### DIFF
--- a/Editor/Generator/MenuGenerator.cs
+++ b/Editor/Generator/MenuGenerator.cs
@@ -86,8 +86,13 @@ namespace dog.miruku.inventory
                 {
                     if (component.GetType().Name == "ModularAvatarMenuInstallTarget")
                     {
+                        var installerField = component.GetType().GetField("installer");
+                        var targetInstaller = installerField.GetValue(component) as ModularAvatarMenuInstaller;
+
+                        if (targetInstaller != menuInstaller) continue;
+
                         // Set serialized field "installer" to the new installer
-                        component.GetType().GetField("installer")?.SetValue(component, newMenuInstaller);
+                        installerField.SetValue(component, newMenuInstaller);
                         EditorUtility.SetDirty(component);
                     }
                 }


### PR DESCRIPTION
# 문제 상황
![image](https://github.com/user-attachments/assets/6dcf9993-3618-4822-9192-895189277618)
인스톨러 통합 옵션 설정하면
![image](https://github.com/user-attachments/assets/36dde631-ecf3-408f-b264-61030fdf6008)
아바타에 포함된 모든 인스톨러 타겟을
![image](https://github.com/user-attachments/assets/77f5456a-edd3-4ca5-8d6d-a15085e9af5e)
대체하게 됩니다.

# 수정 사항
ModularAvatarInstallerTarget의 installer가 대체하려는 ModularAvatarInstaller와 같은지 검사합니다.