### PR TITLE
인벤토리 아이템 값 검증

### DIFF
--- a/Runtime/Components/Inventory.cs
+++ b/Runtime/Components/Inventory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEngine.Serialization;
 using VRC.SDKBase;
@@ -39,7 +40,6 @@ namespace dog.miruku.inventory.runtime
 
         [FormerlySerializedAs("_closetName")] [SerializeField]
         private string _name;
-
         public string Name => _name;
 
         [SerializeField] private Texture2D _customIcon;
@@ -109,6 +109,21 @@ namespace dog.miruku.inventory.runtime
         private void Reset()
         {
             _name = gameObject.name;
+        }
+
+        private void OnValidate()
+        {
+            if (!IsValidName(_name))
+            {
+                Debug.LogError($"[One-Click Inventory] 아이템의 이름에 사용할 수 없는 문자가 포함되어 있습니다: {_name}");
+                Debug.LogError($"[One-Click Inventory] 아이템의 이름에 [<>:\"/\\|?*]는 사용할 수 없습니다.");
+                _name = "Invalid_Name";
+            }
+        }
+
+        private bool IsValidName(string input)
+        {
+            return !string.IsNullOrWhiteSpace(input) && !Regex.IsMatch(input, "[<>:\"/\\|?*]");
         }
     }
 }


### PR DESCRIPTION
인벤토리 아이템의 이름에 상응하는 실제 시스템 디렉토리를 생성하지만, 이 때 인벤토리 아이템의 값 검증이 없기 때문에 문제가 발생합니다. 
Windows에서는 [<>:\"/\\|?*] 문자를 폴더나 파일 이름에 사용할 수 없습니다. 따라서, 해당 문자가 아이템에 포함되는 경우 오류가 발생하지만, 이로 인해 발생하는 에러 로그는 일반 사용자들이 이해하기 어려운 문제가 있습니다. 따라서, 해당 오류가 발생하기 전 값을 검증하는 과정이 필요합니다.
해당 문자가 인벤토리 아이템에서 발견될 경우, 이름을 강제로 수정하고, 유니티 인스펙터에서 경고를 띄우도록(좀 더 사용자가 쉽게 오류를 알 수 있도록) 수정했습니다.

(관련 에러 로그 첨부드립니다. 해당 오류는 아이템 이름에 School?을 사용했을 때 발생한 오류로, 아이템 이름에 ? 문자가 들어가 경로 생성 시 문제가 발생했습니다.)
[inventory_invalid_char_error.txt](https://github.com/user-attachments/files/18817071/inventory_invalid_char_error.txt)
